### PR TITLE
Make cpu_collect compatible with OSX and use gstdbuf

### DIFF
--- a/scripts/cpu_collect.sh
+++ b/scripts/cpu_collect.sh
@@ -8,19 +8,19 @@ set -e
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 
-refresh_interval=$(get_tmux_option "status-interval" "5")
-samples_count="60"
+refresh_interval=$(get_tmux_option "status-interval" "5")/2
+samples_count="2"
 cpu_metric_file="$(get_tmux_option "@sysstat_cpu_tmp_dir" "/dev/null")/cpu_collect.metric"
 
 get_cpu_usage() {
   if is_osx; then
     if command_exists "iostat"; then
       iostat -w "$refresh_interval" -c "$samples_count" \
-        | stdbuf -o0 awk 'NR > 2 { print 100-$(NF-3); }'
+        | gstdbuf -o0 awk 'NR > 2 { print 100-$(NF-3); }'
     else
       top -l "$samples_count" -s "$refresh_interval" -n 0 \
         | sed -u -nr '/CPU usage/s/.*,[[:space:]]*([0-9]+[.,][0-9]*)%[[:space:]]*idle.*/\1/p' \
-        | stdbuf -o0 awk '{ print 100-$0 }'
+        | gstdbuf -o0 awk '{ print 100-$0 }'
     fi
   elif ! command_exists "vmstat"; then
     if is_freebsd; then


### PR DESCRIPTION
https://github.com/samoshkin/tmux-plugin-sysstat/issues/5

### Environment

* OSX Sierra 10.12.6
* zsh 5.2 (x86_64-apple-darwin16.0)
* coreutils: stable 8.29 (bottled)

### Problems

`iostat` intervals are buffered-- even while using `stdbuf`-- until all intervals are complete. This makes the `cpu_collect` script not update the statusline for TMUX as a refresh happens before all intervals are completed (ie. nothing gets written to the corresponding tmp file).

### Changes

* Use the `g` prefixed `gstdbuf` on OSX as to not require modifying the user PATH.
* Modify *refresh_interval* and *samples_count* to complete two samples of `iostat` per TMUX status line refresh.
